### PR TITLE
Configure xml reader to coalesce adjacent character data sections

### DIFF
--- a/src/main/java/com/lyncode/xml/XmlReader.java
+++ b/src/main/java/com/lyncode/xml/XmlReader.java
@@ -46,6 +46,10 @@ public class XmlReader {
     private static final XMLInputFactory XML_INPUT_FACTORY = XMLInputFactory2.newFactory();
     private final XMLEventReader xmlEventParser;
 
+    static {
+        XML_INPUT_FACTORY.setProperty(XMLInputFactory.IS_COALESCING, true);
+    }
+
     public XmlReader(InputStream stream) throws XmlReaderException {
         try {
             this.xmlEventParser = XML_INPUT_FACTORY.createXMLEventReader(stream);


### PR DESCRIPTION
This change should allow to parse correctly data sections that contain mixed text and XML entities, e.g.:
```
<field name="description">&#60;p&#62;Description&#60;/p&#62;</field>
```